### PR TITLE
Correctly reading simultaneous streams with DeviceSync

### DIFF
--- a/examples/synctest.py
+++ b/examples/synctest.py
@@ -1,10 +1,39 @@
 #!/usr/bin/env python3
-# coding: utf-8
-
+import time
 import tldevicesync
+import sys
+import blessings
 
-tio = tldevicesync.DeviceSync()
+def get(d, keys):
+    if "." in keys:
+        key, rest = keys.split(".", 1)
+        if key in d:
+          return get(d[key], rest)
+        else:
+          return None
+    else:
+      if keys in d:
+        return d[keys]
+      else:
+        None
 
-syncStreams = tio.syncStreamsStart([tio.vmr0.vector,tio.vmr1.vector])
-data = tio.syncStreamsRead(syncStreams, samples=3)
-print(data)
+rpc = [
+  ['vector.data.decimation', 'i32', '40'],
+  ]
+tio = tldevicesync.DeviceSync(connectionTime=5, rpcs=rpc)
+
+devices = [tio.vmr0, tio.vmr1]
+streams = ['vector', 'accel']
+ss = tldevicesync.SyncStream(devices=devices,streams=streams)
+    
+term = blessings.Terminal()
+fields = ['time', 'vector.x', 'vector.y', 'vector.z', 'accel.x', 'accel.y', 'accel.z', 'gyro.x', 'gyro.y', 'gyro.z', 'bar', 'therm']
+for row in ss.iter():
+  for name, device in row.items():
+    sys.stdout.write(f"\r\n{term.clear_eol}{name}")
+    for field in fields:
+      data = get(device, field)
+      sys.stdout.write(f"\r\n {field}: {data or ''}")
+  sys.stdout.write(f"\r\n")
+  sys.stdout.write(term.clear_eos)
+  sys.stdout.write(term.move_up*(1+len(row)*(len(fields)+3)))

--- a/tio/tio_session.py
+++ b/tio/tio_session.py
@@ -36,6 +36,9 @@ class TIOSession(object):
     logging.basicConfig(level=logLevel)
     self.logger = logging.getLogger('tio-session')
 
+    # Set RPC's
+    self.rpcs = rpcs
+
     # Connect to either TCP socket or serial port
     self.uri = urllib.parse.urlparse(url)
     if self.uri.scheme in ["tcp", "udp"]:
@@ -111,9 +114,11 @@ class TIOSession(object):
     # Don't specialize if you don't have a solid connection yet (ie in multi device sync)
     self.specialized = False
     if specialize:
-      self.specialize(rpcs=rpcs, stateCache=stateCache, connectingMessage=connectingMessage)
+      self.specialize(rpcs=self.rpcs, stateCache=stateCache, connectingMessage=connectingMessage)
 
   def specialize(self, rpcs=[], stateCache=True, connectingMessage=True):
+    if not rpcs:
+      rpcs = self.rpcs
     # Startup RPCs
     for topic, rpcType, value in rpcs:
       if type(rpcType) is str: # Find type from dict of types

--- a/tldevice/tl_cmd_data.py
+++ b/tldevice/tl_cmd_data.py
@@ -10,7 +10,8 @@ import tio
 class TwinleafDataController(object):
   def __init__(self, dev):
     self._dev = dev
-    self.stream = self._dev._tio.stream_read_raw
+    # Not used
+    # self.stream = self._dev._tio.stream_read_raw
 
   def columnnames(self):
     return self._dev._tio.protocol.columns

--- a/tldevice/tldevice.py
+++ b/tldevice/tldevice.py
@@ -21,9 +21,9 @@ class Device():
     if specialize:
       self._specialize()
   
-  def _specialize(self):
+  def _specialize(self, stateCache = True):
     if not self._tio.specialized:
-      self._tio.specialize()
+      self._tio.specialize(stateCache=stateCache)
     self._add_sources()
     self._add_rpcs()
     if self._tio.protocol.sources != {}:

--- a/tldevicesync/tldevicesync.py
+++ b/tldevicesync/tldevicesync.py
@@ -55,6 +55,9 @@ class DeviceSync():
 
 class SyncStream():
   def __init__(self, devices = [], streams = []):
+    for device in devices:
+      if not isinstance(device, tldevice.Device):
+        raise Exception("Not a valid device")
     self.devices = devices
     self.streams = streams
 

--- a/tldevicesync/tldevicesync.py
+++ b/tldevicesync/tldevicesync.py
@@ -82,7 +82,7 @@ class SyncStream():
           # if max_deviation > 5:
           #   raise Exception("Can't sync stream!")
 
-  def read(self, sync=True, parse=False):
+  def read(self, sync=True):
     if sync:
       self.sync()
 
@@ -100,9 +100,6 @@ class SyncStream():
       self.sync()
       print(f"Streams out of sync by {delta}!")
       # raise Exception(f"Streams out of sync by {delta}!")
-
-    if parse:
-      return map(lambda row: device._tio.parse_data(row), streamdata)
 
     return streamdata
 

--- a/tldevicesync/tldevicesync.py
+++ b/tldevicesync/tldevicesync.py
@@ -92,6 +92,7 @@ class SyncStream():
     for device in self.devices:
       time, data = device._tio.stream_read_raw(flush=False)
       parsedData = device._tio.get_topics_from_data(data, self.streams)
+      parsedData['time'] = time
       streamdata[device._shortname] = parsedData
       starttimes.append(time)
     


### PR DESCRIPTION
Fixes #4 

There were a few problems:
- Startup RPC's were applied to the SYNC device, and not to the connected sensors. It now has a `rpc` argument for the sensors and `rpcSync` for the SYNC device.
- Using the stateCache led to issues. The workaround is not to use it but the real fix is to validate it in some way (however I'm not sure what it is used for and how it is used)
- Synchronized streams did not work properly:
  - Streams that were out of sync too much would quickly raise an exception.
  - The stream data was retrieved directly from the individual stream, instead of obtained from the data packet. This meant that each packet would only provide one set of stream data, and the next stream would be obtained from the next packet with a different timestamp (so it wasn't synchronized on one sensor).
- `stream_read_raw` did not seem to be used so I adapted it and added some methods for synchronously obtaining data from a SYNC device. The data is parsed into a dictionary in SyncStream. To access the `vector` data: `sample[deviceName]['vector'][axis]`, e.g. `sample['vmr0']['vector']['x']`. This in my opinion is the most straightforward way to interpret the obtained data, as there are multiple devices and streams available. If one needs a different structure, `ss.iter()` can be used to create it manually.

I also updated synctest.py with an example. There should be no breaking changes to anything other than the methods in DeviceSync.