### PR TITLE
Fix several bugs in tiologparse

### DIFF
--- a/tiotools/tiologparse.py
+++ b/tiotools/tiologparse.py
@@ -243,7 +243,7 @@ def main():
           time = float(linesegment.split('\t')[0])
         except:
           break
-        while time <= firsttime:
+        while time < firsttime:
           linesegment = fd.readline()
           try:
             time = float(linesegment.split('\t')[0])

--- a/tiotools/tiologparse.py
+++ b/tiotools/tiologparse.py
@@ -165,8 +165,6 @@ def main():
       tempfiles.pop(route)
       tempfilenames.pop(route)
       sensors.pop(route)
-      datarates.pop(route)
-      finaltimes.pop(route)
       routes.remove(route)
 
   

--- a/tiotools/tiologparse.py
+++ b/tiotools/tiologparse.py
@@ -155,8 +155,7 @@ def main():
   [print(f"- {route}") for route in routes]
   
   if args.separate:
-    exit
-    stop
+    exit(0)
 
   # Remove routes that don't have valid start times
   for idx,route in enumerate(list(routes)): # copy the routes


### PR DESCRIPTION
- [x] Adds the first line to the combined output. This line is currently skipped.
- [x] Removes `.pop` of `datarates` and `finaltimes` on missing timing metadata, since these are undefined. Fixes `KeyError: '/0/'`
- [x] Fixes `exit` when using `--separate` flag.